### PR TITLE
Fix package interdependencies

### DIFF
--- a/hdf5_map_io/CMakeLists.txt
+++ b/hdf5_map_io/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(catkin REQUIRED)
 find_package(HDF5 REQUIRED COMPONENTS C CXX HL)
 
 catkin_package(
-  INCLUDE_DIRS include
+  INCLUDE_DIRS include ext/HighFive/include
   LIBRARIES hdf5_map_io
   DEPENDS HDF5
 )

--- a/label_manager/CMakeLists.txt
+++ b/label_manager/CMakeLists.txt
@@ -26,6 +26,7 @@ generate_messages(DEPENDENCIES
 )
 
 catkin_package(
+  INCLUDE_DIRS include
   CATKIN_DEPENDS
   actionlib actionlib_msgs genmsg mesh_msgs message_generation message_runtime roscpp sensor_msgs std_msgs tf
 )

--- a/mesh_msgs_hdf5/CMakeLists.txt
+++ b/mesh_msgs_hdf5/CMakeLists.txt
@@ -5,6 +5,7 @@ project(mesh_msgs_hdf5)
 set(PACKAGE_DEPENDENCIES
   mesh_msgs
   hdf5_map_io
+  label_manager
 )
 
 find_package(catkin REQUIRED COMPONENTS ${PACKAGE_DEPENDENCIES})

--- a/mesh_msgs_hdf5/package.xml
+++ b/mesh_msgs_hdf5/package.xml
@@ -9,7 +9,9 @@
   <author email="spuetz@uos.de">Sebastian Pütz</author>
   <build_depend>mesh_msgs</build_depend>
   <build_depend>hdf5_map_io</build_depend>
+  <build_depend>label_manager</build_depend>
   <run_depend>mesh_msgs</run_depend>
   <run_depend>hdf5_map_io</run_depend>
+  <run_depend>label_manager</run_depend>
   <buildtool_depend>catkin</buildtool_depend>
 </package>


### PR DESCRIPTION
When building the packages, some were complaining about not finding others' include files. This PR fixes those errors for devel but probably not for install (e.g. install target for HighFive is missing).