### PR TITLE
Fix url

### DIFF
--- a/rviz_map_plugin/package.xml
+++ b/rviz_map_plugin/package.xml
@@ -12,7 +12,7 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <license>BSD-3</license>
-  <url>http://ros.org/wiki/mash_tools/rviz_map_plugin</url>
+  <url>https://github.com/uos/mesh_tools/tree/master/rviz_map_plugin</url>
   <build_depend>qtbase5-dev</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rviz</build_depend>


### PR DESCRIPTION
The url was dead. This fixes the hyperlinks in the [status page](http://repositories.ros.org/status_page/ros_noetic_default.html)