### PR TITLE
Fix segfault when using non-textured, but colored materials

### DIFF
--- a/rviz_map_plugin/src/MeshDisplay.cpp
+++ b/rviz_map_plugin/src/MeshDisplay.cpp
@@ -882,7 +882,7 @@ void MeshDisplay::requestMaterials(std::string uuid)
     for (int i = 0; i < meshMaterialsStamped->mesh_materials.materials.size(); i++)
     {
       const mesh_msgs::MeshMaterial& mat = meshMaterialsStamped->mesh_materials.materials[i];
-      materials[i].textureIndex = mat.texture_index;
+      if (mat.has_texture) materials[i].textureIndex = mat.texture_index;
       materials[i].color = Color(mat.color.r, mat.color.g, mat.color.b, mat.color.a);
     }
     for (int i = 0; i < meshMaterialsStamped->mesh_materials.clusters.size(); i++)
@@ -890,11 +890,11 @@ void MeshDisplay::requestMaterials(std::string uuid)
       const mesh_msgs::MeshFaceCluster& clu = meshMaterialsStamped->mesh_materials.clusters[i];
 
       uint32_t materialIndex = meshMaterialsStamped->mesh_materials.cluster_materials[i];
-      const mesh_msgs::MeshMaterial& mat = meshMaterialsStamped->mesh_materials.materials[materialIndex];
+      // const mesh_msgs::MeshMaterial& mat = meshMaterialsStamped->mesh_materials.materials[materialIndex];
 
       for (uint32_t face_index : clu.face_indices)
       {
-        materials[i].faceIndices.push_back(face_index);
+        materials[materialIndex].faceIndices.push_back(face_index);
       }
     }
 


### PR DESCRIPTION
I added a check for `has_texture` from the `MeshMaterial` message so `textureIndex` would resolve `false` for `enteringTexturedTriangleMesh` to fix a segfault for non-textured, but colored materials. Otherwise, the `textureIndex` would be set to whatever value and Rviz would proceed to segfault since that `textureIndex` may not be a valid index (i.e. if there weren't any textures whatsoever). This was a problem with `rospy` since the automatic serialization would always associate a value to `texture_index`, and the `boost::optional<uint32_t>` would never evaluate `false`. I don't know if this occurs in `roscpp` as well.

Additionally I changed the cluster material association part of the material service request function so that each cluster would use the respective material from `cluster_materials` instead of the material with the identical index to the cluster. Since it also looked like a nearby line was not used for anything, I commented that out as well.

Since this was only a 3 line change, I combined it into one commit. Hopefully that isn't a problem!